### PR TITLE
feat(theme): add dark/light mode toggle with theme persistence

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,11 +2,13 @@ import Generator from './components/generator'
 import { Toaster } from 'sonner'
 import Header from './components/header'
 import { Footer } from './components/footer'
+import { Navigation } from './components/navigation'
 import { motion } from 'framer-motion'
 
 export default function App() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-muted/20 to-accent/30 flex flex-col">
+      <Navigation />
       <div className="flex-1">
         <motion.div
           className="container mx-auto py-12 px-4"

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,0 +1,33 @@
+import { ThemeToggle } from '@/components/ui/theme-toggle'
+import { Github } from 'lucide-react'
+import { motion } from 'framer-motion'
+
+export function Navigation() {
+  return (
+    <motion.nav
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.2 }}
+      className="fixed top-4 right-4 z-50"
+    >
+      <motion.div
+        initial={{ scale: 0.8 }}
+        animate={{ scale: 1 }}
+        transition={{ duration: 0.3, delay: 0.4 }}
+        className="flex items-center gap-2 p-2 bg-card/80 backdrop-blur-sm border border-border/50 rounded-full shadow-lg"
+      >
+        <motion.a
+          href="https://github.com/MrHacker26/pkce-generator"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="p-2 hover:bg-accent/50 rounded-full transition-colors"
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.9 }}
+        >
+          <Github className="h-4 w-4" />
+        </motion.a>
+        <ThemeToggle />
+      </motion.div>
+    </motion.nav>
+  )
+}

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,44 @@
+import { MoonIcon, SunIcon } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useTheme } from '@/hooks/use-theme'
+import { motion, AnimatePresence } from 'framer-motion'
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme()
+
+  return (
+    <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={toggleTheme}
+        className="size-9 rounded-md border border-border/50 bg-background/50 backdrop-blur-sm hover:bg-accent/50 relative overflow-hidden"
+      >
+        <AnimatePresence mode="wait">
+          {theme === 'dark' ? (
+            <motion.div
+              key="sun"
+              initial={{ opacity: 0, rotate: -90, scale: 0.5 }}
+              animate={{ opacity: 1, rotate: 0, scale: 1 }}
+              exit={{ opacity: 0, rotate: 90, scale: 0.5 }}
+              transition={{ duration: 0.3, ease: 'easeInOut' }}
+            >
+              <SunIcon className="size-4" />
+            </motion.div>
+          ) : (
+            <motion.div
+              key="moon"
+              initial={{ opacity: 0, rotate: 90, scale: 0.5 }}
+              animate={{ opacity: 1, rotate: 0, scale: 1 }}
+              exit={{ opacity: 0, rotate: -90, scale: 0.5 }}
+              transition={{ duration: 0.3, ease: 'easeInOut' }}
+            >
+              <MoonIcon className="h-4 w-4" />
+            </motion.div>
+          )}
+        </AnimatePresence>
+        <span className="sr-only">Toggle theme</span>
+      </Button>
+    </motion.div>
+  )
+}

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+
+type Theme = 'dark' | 'light' | 'system'
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('theme') as Theme) || 'system'
+    }
+    return 'system'
+  })
+
+  useEffect(() => {
+    const root = window.document.documentElement
+    root.classList.remove('light', 'dark')
+
+    if (theme === 'system') {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+      root.classList.add(systemTheme)
+    } else {
+      root.classList.add(theme)
+    }
+  }, [theme])
+
+  function setThemeWithStorage(newTheme: Theme) {
+    localStorage.setItem('theme', newTheme)
+    setTheme(newTheme)
+  }
+
+  function toggleTheme() {
+    setThemeWithStorage(theme === 'dark' ? 'light' : 'dark')
+  }
+
+  return {
+    theme,
+    setTheme: setThemeWithStorage,
+    toggleTheme,
+  }
+}


### PR DESCRIPTION
### 📚 Description

This PR implements a dark/light mode toggle feature with theme persistence using localStorage. Users can now switch between themes, and their preference is saved across sessions.

### ✅ Changes

- Added toggle button for switching themes.
- Used `localStorage` to persist theme across page reloads.

### 🔗 Related Issue

Closes #1